### PR TITLE
SLURM + singularity support for HPC

### DIFF
--- a/configs/slurm.config
+++ b/configs/slurm.config
@@ -1,7 +1,7 @@
 workDir = params.workdir
 
 executor {
-    name = "lsf"
+    name = "slurm"
     queueSize = 200
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -45,11 +45,16 @@ profiles {
         includeConfig 'configs/lsf.config'
  }
 
+ slurm {
+        params.cloudProcess = true
+        includeConfig 'configs/slurm.config'
+ }
+
  ebi {
         params.cloudProcess = true
-  	  params.workdir = "/hps/nobackup2/production/metagenomics/$USER/nextflow-work-$USER"
-  	  params.cloudDatabase = "/homes/$USER/data/nextflow-databases/"
-  	  params.cachedir = "/hps/nobackup2/singularity/$USER"	
+  	 params.workdir = "/hps/nobackup2/production/metagenomics/$USER/nextflow-work-$USER"
+  	 params.cloudDatabase = "/homes/$USER/data/nextflow-databases/"
+  	 params.cachedir = "/hps/nobackup2/singularity/$USER"	
         includeConfig 'configs/lsf.config'
  }
 


### PR DESCRIPTION
Looks like the Nextflow configs for Slurm + singularity are all there, just a matter of merging the two branches.

This would be in addition to LSF support which WtP has now.