### PR TITLE
Testing  virome flag

### DIFF
--- a/bin/heatmap.R
+++ b/bin/heatmap.R
@@ -16,7 +16,7 @@ filein <- args[1]
 
 # own input
 df <- read.table(filein, sep=",", header = TRUE)
-df <- read.table("summary.csv", sep=",", header = TRUE)
+
 
 # count rows to resize y axis
 resize <- ( (ncol(df)*0.3) +2)

--- a/modules/parser/filter_deepvirfinder.nf
+++ b/modules/parser/filter_deepvirfinder.nf
@@ -6,6 +6,6 @@ process filter_deepvirfinder {
       tuple val(name), file("deepvirfinder_*.txt")
     shell:
       """
-      tail -n+2 *.list | sort -g  -k4,4  | awk '\$3>=0.9' | awk '{ print \$1 }'  > deepvirfinder_\${PWD##*/}.txt
+      tail -n+2 *.list | sort -g  -k4,4  | awk '\$3>=${params.dv_filter}' | awk '{ print \$1 }'  > deepvirfinder_\${PWD##*/}.txt
       """
 }

--- a/modules/parser/filter_metaphinder.nf
+++ b/modules/parser/filter_metaphinder.nf
@@ -6,7 +6,7 @@ process filter_metaphinder {
       tuple val(name), file("metaphinder_*.txt")
     script:
       """
-      cat *.list | sort -g -k4,4 | tail -n+2 | awk '{if(\$2=="phage" && \$3>50.0){print \$1}}'  > metaphinder_\${PWD##*/}.txt
+      cat *.list | sort -g -k4,4 | tail -n+2 | awk '{if(\$2=="phage" && \$3>${params.mp_filter}){print \$1}}'  > metaphinder_\${PWD##*/}.txt
       """
 }
 // filter for phage and %Ani >50
@@ -18,6 +18,6 @@ process filter_metaphinder_own_DB {
       tuple val(name), file("metaphinder-own-DB_*.txt")
     script:
       """
-      cat *.list | sort -g -k4,4 | tail -n+2 | awk '{if(\$2=="phage" && \$3>50.0){print \$1}}'  > metaphinder-own-DB_\${PWD##*/}.txt
+      cat *.list | sort -g -k4,4 | tail -n+2 | awk '{if(\$2=="phage" && \$3>${params.mp_filter}){print \$1}}'  > metaphinder-own-DB_\${PWD##*/}.txt
       """
 }

--- a/modules/parser/filter_vibrant.nf
+++ b/modules/parser/filter_vibrant.nf
@@ -9,3 +9,15 @@ process filter_vibrant {
       tail -q  -n+2 *.tsv | awk '{if(\$2=="virus"){print \$1}}' | sed -r 's/_fragment_[0-9]//' > vibrant_\${PWD##*/}.txt
       """
 }
+
+process filter_vibrant_virome {
+      label 'ubuntu'
+    input:
+      tuple val(name), file(results) 
+    output:
+      tuple val(name), file("vibrant-virome_*.txt")
+    script:
+      """
+      tail -q  -n+2 *.tsv | awk '{if(\$2=="virus"){print \$1}}' | sed -r 's/_fragment_[0-9]//' > vibrant-virome_\${PWD##*/}.txt
+      """
+}

--- a/modules/parser/filter_virfinder.nf
+++ b/modules/parser/filter_virfinder.nf
@@ -6,6 +6,6 @@ process filter_virfinder {
       tuple val(name), file("virfinder_*.txt")
     script:
       """
-      tail -q -n+2 *.list | awk '\$4>=0.9' | awk '{ print \$2 }' > virfinder_\${PWD##*/}.txt
+      tail -q -n+2 *.list | awk '\$4>=${params.vf_filter}' | awk '{ print \$2 }' > virfinder_\${PWD##*/}.txt
       """
 }

--- a/modules/parser/filter_virnet.nf
+++ b/modules/parser/filter_virnet.nf
@@ -6,7 +6,7 @@ process filter_virnet {
       tuple val(name), file("virnet_*.txt")
     script:
       """
-      tail -q -n+2 *.csv | sed 's|,|\\t|g' | awk '{if(\$6==1){print \$2}}' | sort | uniq | tr -d '"' > virnet_\${PWD##*/}.txt
+      tail -q -n+2 *.csv | sed 's|,|\\t|g' | awk '{if(\$6==${params.vn_filter}){print \$2}}' | sort | uniq | tr -d '"' > virnet_\${PWD##*/}.txt
       """
 }
 // filter for "score"

--- a/modules/parser/filter_virsorter.nf
+++ b/modules/parser/filter_virsorter.nf
@@ -9,3 +9,15 @@ process filter_virsorter {
       cat *.list  > virsorter_\${PWD##*/}.txt
       """
 }
+
+process filter_virsorter_virome {
+      label 'ubuntu'
+    input:
+      tuple val(name), file(results), file(dir)
+    output:
+      tuple val(name), file("virsorter-virome_*.txt")
+    shell:
+      """
+      cat *.list  > virsorter-virome_\${PWD##*/}.txt
+      """
+}

--- a/modules/raw_data_collection/vibrant_collect_data.nf
+++ b/modules/raw_data_collection/vibrant_collect_data.nf
@@ -14,3 +14,21 @@ process vibrant_collect_data {
       tar -czf vibrant_results_${name}.tar.gz vibrant
       """
 }
+
+
+process vibrant_virome_collect_data {
+      publishDir "${params.output}/${name}/raw_data", mode: 'copy', pattern: "vibrant_virome_results_${name}.tar.gz"
+      label 'ubuntu'
+    input:
+      tuple val(name), file(output_lists), file(dirs)
+    output:
+      tuple val(name), file("vibrant_virome_results_${name}.tar.gz")
+    script:
+      """
+      mkdir -p vibrant/results
+      cp ${dirs} vibrant/results/
+      cat ${output_lists} | head -1 > vibrant/${name}_overview.txt
+      tail -q -n +2 ${output_lists} >> vibrant/${name}_overview.txt
+      tar -czf vibrant_virome_results_${name}.tar.gz vibrant
+      """
+}

--- a/modules/raw_data_collection/virsorter_collect_data.nf
+++ b/modules/raw_data_collection/virsorter_collect_data.nf
@@ -12,3 +12,18 @@ process virsorter_collect_data {
       tar -czf virsorter_results_${name}.tar.gz virsorter
       """
 }
+
+process virsorter_virome_collect_data {
+      publishDir "${params.output}/${name}/raw_data", mode: 'copy', pattern: "virsorter_virome_results_${name}.tar.gz"
+      label 'ubuntu'
+    input:
+      tuple val(name), file(tar_files)
+    output:
+      tuple val(name), file("virsorter_virome_results_${name}.tar.gz")
+    script:
+      """
+      mkdir -p virsorter
+      cp ${tar_files} virsorter
+      tar -czf virsorter_virome_results_${name}.tar.gz virsorter
+      """
+}

--- a/modules/tools/sourmash.nf
+++ b/modules/tools/sourmash.nf
@@ -21,7 +21,7 @@ process sourmash {
       touch ${name}_\${PWD##*/}.list
 
       for tempfile in *.temporary; do
-        value=\$(grep -v "similarity,name,filename,md5" \${tempfile} | awk '\$1>=0.5'|wc -l)   # filtering criteria
+        value=\$(grep -v "similarity,name,filename,md5" \${tempfile} | awk '\$1>=${params.sm_filter}'|wc -l)   # filtering criteria
         filename=\$(basename \${tempfile} .fa.sig.temporary)
       
         if [ \$value -gt 0 ] 

--- a/modules/tools/vibrant.nf
+++ b/modules/tools/vibrant.nf
@@ -32,6 +32,40 @@ process vibrant {
       """
 }
 
+process vibrant_virome {
+      label 'vibrant'
+      errorStrategy 'ignore'
+    input:
+      tuple val(name), file(fasta) 
+      path(db)
+    output:
+      tuple val(name), file("vibrant_*.tsv")
+      // output collection stream
+      tuple val(name), file("vibrant_*.tsv"), file("VIBRANT_results_*.tar.gz")
+    script:
+      """
+      
+      tar xzf ${db}
+
+      VIBRANT_run.py -i ${fasta} -t ${task.cpus} \
+      -virome \
+      -k database/KEGG_profiles_prokaryotes.HMM \
+      -p database/Pfam-A_v32.HMM \
+      -v database/VOGDB94_phage.HMM \
+      -e database/Pfam-A_plasmid_v32.HMM \
+      -a database/Pfam-A_phage_v32.HMM \
+      -c database/VIBRANT_categories.tsv \
+      -n database/VIBRANT_names.tsv \
+      -s database/VIBRANT_KEGG_pathways_summary.tsv \
+      -m database/VIBRANT_machine_model.sav \
+      -g database/VIBRANT_AMGs.tsv 
+
+      # error control via touch
+      cp VIBRANT_*/VIBRANT_results_*/VIBRANT_machine_*.tsv vibrant_\${PWD##*/}.tsv 2>/dev/null
+      
+      tar cf VIBRANT_results_\${PWD##*/}.tar.gz VIBRANT_*
+      """
+}
 /*
 
 slows pc down massively.... while tar proces 

--- a/modules/tools/virsorter.nf
+++ b/modules/tools/virsorter.nf
@@ -16,3 +16,22 @@ process virsorter {
       tar cf virsorter_results_\${PWD##*/}.tar virsorter
       """
 }
+
+process virsorter_virome {
+      label 'virsorter'
+      errorStrategy 'ignore'
+    input:
+      tuple val(name), file(fasta) 
+      file(database) 
+    output:
+      tuple val(name), file("virsorter_*.list"), file("virsorter")
+      // output collection stream
+      tuple val(name), file("virsorter_results_*.tar")
+    script:
+      """
+      wrapper_phage_contigs_sorter_iPlant.pl -f ${fasta} -db 1 --virome --wdir virsorter --ncpu \$(( ${task.cpus} * 2 )) --data-dir ${database}
+      cat virsorter/Predicted_viral_sequences/VIRSorter_cat-[1,2].fasta | grep ">" | sed -e s/\\>VIRSorter_//g | sed -e s/-cat_1//g |  sed -e s/-cat_2//g | sed -e s/-circular//g > virsorter_\${PWD##*/}.list
+
+      tar cf virsorter_results_\${PWD##*/}.tar virsorter
+      """
+}

--- a/modules/tools/virsorter.nf
+++ b/modules/tools/virsorter.nf
@@ -10,7 +10,7 @@ process virsorter {
       tuple val(name), file("virsorter_results_*.tar")
     script:
       """
-      wrapper_phage_contigs_sorter_iPlant.pl -f ${fasta} -db 1 --wdir virsorter --ncpu \$(( ${task.cpus} * 2 )) --data-dir ${database}
+      wrapper_phage_contigs_sorter_iPlant.pl -f ${fasta} -db 2 --wdir virsorter --ncpu \$(( ${task.cpus} * 2 )) --data-dir ${database}
       cat virsorter/Predicted_viral_sequences/VIRSorter_cat-[1,2].fasta | grep ">" | sed -e s/\\>VIRSorter_//g | sed -e s/-cat_1//g |  sed -e s/-cat_2//g | sed -e s/-circular//g > virsorter_\${PWD##*/}.list
 
       tar cf virsorter_results_\${PWD##*/}.tar virsorter
@@ -29,7 +29,7 @@ process virsorter_virome {
       tuple val(name), file("virsorter_results_*.tar")
     script:
       """
-      wrapper_phage_contigs_sorter_iPlant.pl -f ${fasta} -db 1 --virome --wdir virsorter --ncpu \$(( ${task.cpus} * 2 )) --data-dir ${database}
+      wrapper_phage_contigs_sorter_iPlant.pl -f ${fasta} -db 2 --virome --wdir virsorter --ncpu \$(( ${task.cpus} * 2 )) --data-dir ${database}
       cat virsorter/Predicted_viral_sequences/VIRSorter_cat-[1,2].fasta | grep ">" | sed -e s/\\>VIRSorter_//g | sed -e s/-cat_1//g |  sed -e s/-cat_2//g | sed -e s/-circular//g > virsorter_\${PWD##*/}.list
 
       tar cf virsorter_results_\${PWD##*/}.tar virsorter

--- a/nextflow.config
+++ b/nextflow.config
@@ -37,6 +37,19 @@ params {
     vn = false
     identify = false
     annotate = false
+
+
+    // raw tool output filters
+    
+    dv = '0.9'
+    ma = '75'
+    mp = '50'
+    vf = '0.9'
+    vs = ''
+    pp = ''
+    sm = '0.5'
+    vb = ''
+    vn = '1'
 }
 
 profiles {

--- a/nextflow.config
+++ b/nextflow.config
@@ -37,19 +37,20 @@ params {
     vn = false
     identify = false
     annotate = false
+    virome = false
 
-
-    // raw tool output filters
+     // raw tool output filters
     
-    dv = '0.9'
-    ma = '75'
-    mp = '50'
-    vf = '0.9'
-    vs = ''
-    pp = ''
-    sm = '0.5'
-    vb = ''
-    vn = '1'
+    dv_filter = '0.9'
+    // ma_filter = '75'
+    mp_filter = '50'
+    vf_filter = '0.9'
+    sm_filter = '0.5'
+    vn_filter = '1'
+    // vs_filter = ''
+    // pp_filter = ''
+    // vb_filter = ''
+
 }
 
 profiles {

--- a/phage.nf
+++ b/phage.nf
@@ -769,10 +769,18 @@ def helpMSG() {
     --vf                deactivates virfinder
     --vn                deactivates virnet
     --vs                deactivates virsorter
-    --virome            deactivates virome-mode of tool
+
+    Adjust tools individually
+    --virome            deactivates virome-mode (vibrand and virsorter)
+    --dv_filter         p-value cut-off [default: $params.dv_filter]
+    --mp_filter         average nucleotide identity [default: $params.mp_filter]
+    --vf_filter         p-value cut-off [default: $params.vf_filter]
+    --sm_filter         Similarity score [default: $params.sm_filter]
+    --vn_filter         Score [default: $params.vn_filter]
+
+    Workflow control:
     --identify          only phage identification, skips analysis
     --annotate          only annotation, skips phage identification
-    --virome            deactivates virome-mode of tool
 
     ${c_yellow}Databases, file, container behaviour:${c_reset}
     --databases         specifiy download location of databases 

--- a/phage.nf
+++ b/phage.nf
@@ -533,7 +533,7 @@ workflow checkV_wf {
 
 workflow get_test_data {
     main: testprofile()
-    emit: testprofile.out.flatten().map { file -> tuple(file.baseName, file) }
+    emit: testprofile.out.flatten().map { file -> tuple(file.simpleName, file) } // or getSimpleName
 }
 
 workflow phage_tax_classification {

--- a/phage.nf
+++ b/phage.nf
@@ -436,7 +436,7 @@ workflow virsorter_wf {
 workflow virsorter_virome_wf {
     take:   fasta
             virsorter_DB
-    main:   if (!params.vs) {
+    main:   if (!params.vs && !params.virome) {
                         virsorter_virome(fasta, virsorter_DB)
                         // filtering
                         filter_virsorter_virome(virsorter_virome.out[0].groupTuple(remainder: true))
@@ -482,7 +482,7 @@ workflow vibrant_wf {
 workflow vibrant_virome_wf {
     take:   fasta
             vibrant_download_DB
-    main:   if (!params.vb) {
+    main:   if (!params.vb && !params.virome) {
                         vibrant_virome(fasta, vibrant_download_DB)
                         // filtering
                         filter_vibrant_virome(vibrant_virome.out[0].groupTuple(remainder: true))

--- a/phage.nf
+++ b/phage.nf
@@ -110,32 +110,24 @@ if (!params.setup && !workflow.profile.contains('test')) {
 *************/
 
     include checkV from './modules/checkV'
-    include download_checkV_DB from './modules/databases/download_checkV_DB'
     include chromomap from './modules/chromomap'
     include chromomap_parser from './modules/parser/chromomap_parser'
     include deepvirfinder from './modules/tools/deepvirfinder'
     include deepvirfinder_collect_data from './modules/raw_data_collection/deepvirfinder_collect_data'
+    include download_checkV_DB from './modules/databases/download_checkV_DB'
     include download_references from './modules/databases/download_references'
     include fastqTofasta from './modules/fastqTofasta'
     include filter_PPRmeta from './modules/parser/filter_PPRmeta'
     include filter_deepvirfinder from './modules/parser/filter_deepvirfinder'
     include filter_marvel from './modules/parser/filter_marvel'
-    include filter_metaphinder from './modules/parser/filter_metaphinder'
-    include filter_metaphinder_own_DB from './modules/parser/filter_metaphinder'
     include filter_sourmash from './modules/parser/filter_sourmash'
     include filter_tool_names from './modules/parser/filter_tool_names'
-    include filter_vibrant from './modules/parser/filter_vibrant'
     include filter_virfinder from './modules/parser/filter_virfinder'
     include filter_virnet from './modules/parser/filter_virnet'
-    include filter_virsorter from './modules/parser/filter_virsorter' 
     include hmmscan from './modules/hmmscan'
     include input_suffix_check from './modules/input_suffix_check'
     include marvel from './modules/tools/marvel'
     include marvel_collect_data from './modules/raw_data_collection/marvel_collect_data'
-    include metaphinder from './modules/tools/metaphinder'
-    include metaphinder_collect_data from './modules/raw_data_collection/metaphinder_collect_data'
-    include metaphinder_collect_data_ownDB from './modules/raw_data_collection/metaphinder_collect_data'
-    include metaphinder_own_DB from './modules/tools/metaphinder'
     include normalize_contig_size from './modules/normalize_contig_size'
     include parse_reads from './modules/parser/parse_reads.nf'
     include phage_references_blastDB from './modules/databases/phage_references_blastDB'
@@ -155,21 +147,26 @@ if (!params.setup && !workflow.profile.contains('test')) {
     include sourmash from './modules/tools/sourmash'
     include sourmash_collect_data from './modules/raw_data_collection/sourmash_collect_data'
     include sourmash_download_DB from './modules/databases/sourmash_download_DB'
+    include sourmash_for_tax from './modules/sourmash_for_tax'
     include split_multi_fasta from './modules/split_multi_fasta'
+    include testprofile from './modules/testprofile'
     include upsetr_plot from './modules/upsetr.nf'
-    include vibrant from './modules/tools/vibrant'
-    include vibrant_collect_data from './modules/raw_data_collection/vibrant_collect_data'
     include vibrant_download_DB from './modules/databases/vibrant_download_DB'
     include virfinder from './modules/tools/virfinder'
     include virfinder_collect_data from './modules/raw_data_collection/virfinder_collect_data'
     include virnet from './modules/tools/virnet'
     include virnet_collect_data from './modules/raw_data_collection/virnet_collect_data'
-    include virsorter from './modules/tools/virsorter'
-    include virsorter_collect_data from './modules/raw_data_collection/virsorter_collect_data'
     include virsorter_download_DB from './modules/databases/virsorter_download_DB'
     include vog_DB from './modules/databases/download_vog_DB'
-    include sourmash_for_tax from './modules/sourmash_for_tax'
-    include testprofile from './modules/testprofile'
+    include { filter_metaphinder; filter_metaphinder_own_DB } from './modules/parser/filter_metaphinder'
+    include { filter_vibrant; filter_vibrant_virome } from './modules/parser/filter_vibrant'
+    include { filter_virsorter; filter_virsorter_virome } from './modules/parser/filter_virsorter' 
+    include { metaphinder; metaphinder_own_DB} from './modules/tools/metaphinder'
+    include { metaphinder_collect_data; metaphinder_collect_data_ownDB } from './modules/raw_data_collection/metaphinder_collect_data'
+    include { vibrant; vibrant_virome } from './modules/tools/vibrant'
+    include { vibrant_collect_data; vibrant_virome_collect_data } from './modules/raw_data_collection/vibrant_collect_data'
+    include { virsorter; virsorter_virome } from './modules/tools/virsorter'
+    include { virsorter_collect_data; virsorter_virome_collect_data } from './modules/raw_data_collection/virsorter_collect_data'
 
 /************* 
 * DATABASES for Phage Identification
@@ -436,6 +433,22 @@ workflow virsorter_wf {
     emit:   virsorter_results
 } 
 
+workflow virsorter_virome_wf {
+    take:   fasta
+            virsorter_DB
+    main:   if (!params.vs) {
+                        virsorter_virome(fasta, virsorter_DB)
+                        // filtering
+                        filter_virsorter_virome(virsorter_virome.out[0].groupTuple(remainder: true))
+                        // raw data collector
+                        virsorter_virome_collect_data(virsorter_virome.out[1].groupTuple(remainder: true))
+                        // result channel
+                        virsorter_virome_results = filter_virsorter_virome.out
+                        }
+            else { virsorter_virome_results = Channel.from( [ 'deactivated', 'deactivated'] ) }
+    emit:   virsorter_virome_results
+} 
+
 workflow pprmeta_wf {
     take:   fasta
             ppr_deps
@@ -464,6 +477,22 @@ workflow vibrant_wf {
                         }
             else { vibrant_results = Channel.from( [ 'deactivated', 'deactivated'] ) }
     emit:   vibrant_results
+}
+
+workflow vibrant_virome_wf {
+    take:   fasta
+            vibrant_download_DB
+    main:   if (!params.vb) {
+                        vibrant_virome(fasta, vibrant_download_DB)
+                        // filtering
+                        filter_vibrant_virome(vibrant_virome.out[0].groupTuple(remainder: true))
+                        // raw data collector
+                        vibrant_virome_collect_data(vibrant_virome.out[1].groupTuple(remainder: true))
+                        // result channel
+                        vibrant_virome_results = filter_vibrant_virome.out
+                        }
+            else { vibrant_virome_results = Channel.from( [ 'deactivated', 'deactivated'] ) }
+    emit:   vibrant_virome_results
 }
 
 workflow virnet_wf {
@@ -560,6 +589,7 @@ workflow identify_fasta_MSF {
 
         // gather results
             results =   virsorter_wf(fasta_validation_wf.out, virsorter_DB)
+                        .concat(virsorter_virome_wf(fasta_validation_wf.out, virsorter_DB))
                         .concat(marvel_wf(fasta_validation_wf.out))      
                         .concat(sourmash_wf(fasta_validation_wf.out, sourmash_DB))
                         .concat(metaphinder_wf(fasta_validation_wf.out))
@@ -568,12 +598,13 @@ workflow identify_fasta_MSF {
                         .concat(virfinder_wf(fasta_validation_wf.out))
                         .concat(pprmeta_wf(fasta_validation_wf.out, ppr_deps))
                         .concat(vibrant_wf(fasta_validation_wf.out, vibrant_DB))
+                        .concat(vibrant_virome_wf(fasta_validation_wf.out, vibrant_DB))
                         .concat(virnet_wf(fasta_validation_wf.out))
                         .filter { it != 'deactivated' } // removes deactivated tool channels
                         .groupTuple()
                         
             filter_tool_names(results) 
-                        
+                                               
         //plotting results
             r_plot(filter_tool_names.out)
             upsetr_plot(filter_tool_names.out)

--- a/phage.nf
+++ b/phage.nf
@@ -769,8 +769,10 @@ def helpMSG() {
     --vf                deactivates virfinder
     --vn                deactivates virnet
     --vs                deactivates virsorter
+    --virome            deactivates virome-mode of tool
     --identify          only phage identification, skips analysis
     --annotate          only annotation, skips phage identification
+    --virome            deactivates virome-mode of tool
 
     ${c_yellow}Databases, file, container behaviour:${c_reset}
     --databases         specifiy download location of databases 


### PR DESCRIPTION
* this branch was tested on test-data/T7_draft.fasta
* contains virome mode of virsorter and vibrant as additional output (this pr closes #81 )
* virsorter also uses db 2 from now on( #81 )
* virome mode can be deactivated via  --virome flag
* contains adjustable raw output filter for more control (currently dv, mp,vf,sm,vn )
