### PR TITLE
upgrade sourmash to 3.4.1, use zipped databases

### DIFF
--- a/configs/container.config
+++ b/configs/container.config
@@ -13,7 +13,7 @@ process {
     withLabel: python           { container = 'nanozoo/template:3.8--ccd0653' }
     withLabel: samtools         { container = 'nanozoo/samtools:1.9--76b9270' }
     withLabel: seqkit           { container = 'nanozoo/seqkit:0.10.1--360dd6d' }
-    withLabel: sourmash         { container = 'quay.io/biocontainers/sourmash:3.4.1--0'  }
+    withLabel: sourmash         { container = 'nanozoo/sourmash:3.4.1--16a8db7'  }
     withLabel: ubuntu           { container = 'nanozoo/basics:1.0--962b907' }
     withLabel: upsetr           { container = 'nanozoo/upsetr:1.4.0--0ea25b3' }
     withLabel: vibrant          { container = 'multifractal/vibrant:0.4'  }

--- a/configs/container.config
+++ b/configs/container.config
@@ -13,7 +13,7 @@ process {
     withLabel: python           { container = 'nanozoo/template:3.8--ccd0653' }
     withLabel: samtools         { container = 'nanozoo/samtools:1.9--76b9270' }
     withLabel: seqkit           { container = 'nanozoo/seqkit:0.10.1--360dd6d' }
-    withLabel: sourmash         { container = 'nanozoo/sourmash:2.3.0--4257650'  }
+    withLabel: sourmash         { container = 'quay.io/biocontainers/sourmash:3.4.1--0'  }
     withLabel: ubuntu           { container = 'nanozoo/basics:1.0--962b907' }
     withLabel: upsetr           { container = 'nanozoo/upsetr:1.4.0--0ea25b3' }
     withLabel: vibrant          { container = 'multifractal/vibrant:0.4'  }

--- a/modules/databases/sourmash_download_DB.nf
+++ b/modules/databases/sourmash_download_DB.nf
@@ -1,15 +1,14 @@
 process sourmash_download_DB {
-    if (params.cloudProcess) { publishDir "${params.databases}/sourmash/", mode: 'copy', pattern: "phages.sbt.json.tar.gz" }
+    if (params.cloudProcess) { publishDir "${params.databases}/sourmash/", mode: 'copy', pattern: "phages.sbt.zip" }
     else { storeDir "${params.databases}/sourmash/" }
     label 'sourmash' 
     input:
         file(references)
     output:
-        file("phages.sbt.json.tar.gz")
+        file("phages.sbt.zip")
     script:
         """
         sourmash compute --scaled 100 -k 21 --singleton --seed 42 -p 8 -o phages.sig ${references}
-        sourmash index phages phages.sig
-        tar czf phages.sbt.json.tar.gz phages.sbt.json .sbt.phages
+        sourmash index phages.sbt.zip phages.sig
         """
 }

--- a/modules/sourmash_for_tax.nf
+++ b/modules/sourmash_for_tax.nf
@@ -9,8 +9,6 @@ process sourmash_for_tax {
       tuple val(name), file("${name}_tax-class.tsv")
     shell:
       """
-      tar xzf ${database}
-
       for fastafile in ${fasta_dir}/*.fa; do
         sourmash compute -p ${task.cpus} --scaled 100 -k 21 \${fastafile}
       done

--- a/modules/sourmash_for_tax.nf
+++ b/modules/sourmash_for_tax.nf
@@ -16,7 +16,7 @@ process sourmash_for_tax {
       done
 
       for signature in *.sig; do
-        sourmash search -k 21 \${signature} phages.sbt.json -o \${signature}.temporary
+        sourmash search -k 21 \${signature} phages.sbt.zip -o \${signature}.temporary
       done
     
       touch ${name}_tax-class.tsv

--- a/modules/tools/sourmash.nf
+++ b/modules/tools/sourmash.nf
@@ -15,7 +15,7 @@ process sourmash {
       done
 
       for signature in *.sig; do
-        sourmash search -k 21 \${signature} phages.sbt.json -o \${signature}.temporary
+        sourmash search -k 21 \${signature} phages.sbt.zip -o \${signature}.temporary
       done
     
       touch ${name}_\${PWD##*/}.list

--- a/modules/tools/sourmash.nf
+++ b/modules/tools/sourmash.nf
@@ -8,8 +8,6 @@ process sourmash {
       tuple val(name), file("${name}_*.list")
     shell:
       """
-      tar xzf ${database}
-
       for fastafile in ${fasta_dir}/*.fa; do
         sourmash compute -p ${task.cpus} --scaled 100 -k 21 \${fastafile}
       done

--- a/phage.nf
+++ b/phage.nf
@@ -205,7 +205,7 @@ workflow sourmash_database {
         if (!params.cloudProcess) { sourmash_download_DB(references); db = sourmash_download_DB.out }
         // cloud storage via db_preload.exists()
         if (params.cloudProcess) {
-            db_preload = file("${params.databases}/sourmash/phages.sbt.json.tar.gz")
+            db_preload = file("${params.databases}/sourmash/phages.sbt.zip")
             if (db_preload.exists()) { db = db_preload }
             else  { sourmash_download_DB(references); db = sourmash_download_DB.out } 
         }


### PR DESCRIPTION
Hi!

Since sourmash 3.3.0 we support [zipped databases][0], which makes it easier to work with databases (because you don't need to untar them anymore before using). I went thru the code and adapted it to use these zipped SBTs, and also updated the container used for sourmash to 3.4.1, using the [biocontainers][1] that is autobuild for each new bioconda release (I think it is also smaller than the one being used previously?)

Still need to validate results, and I think the new `phages.sbt.zip` need to be uploaded to the cloud storage (I'm not a nextflow user, so correct me if I'm wrong =])

cc @phiweger 

[0]: https://blog.luizirber.org/2020/05/11/sbt-zip/
[1]: https://quay.io/repository/biocontainers/sourmash