### PR TITLE
add max cores function for local runs

### DIFF
--- a/configs/local.config
+++ b/configs/local.config
@@ -1,5 +1,3 @@
-process.executor = 'local'
-
 process {
     withLabel: altair           { cpus = 1 }
     withLabel: chromomap        { cpus = params.cores }

--- a/nextflow.config
+++ b/nextflow.config
@@ -4,6 +4,7 @@ manifest {
 
 params {
     // default parameters
+    max_cores = Runtime.runtime.availableProcessors()    
     cores = "8"
     mem = "12"
     help = false
@@ -73,6 +74,10 @@ profiles {
 
     //executer
     local {
+        executor {
+                name = "local"
+               	cpus = params.max_cores
+        }
         workDir = params.workdir
         params.cloudProcess = false
         includeConfig 'configs/local.config'

--- a/phage.nf
+++ b/phage.nf
@@ -46,7 +46,7 @@ println "  Manually remove faulty images in $params.cachedir for a rebuild\u001B
 if (params.annotate) { println "\u001B[33mSkipping phage identification for fasta files\u001B[0m" }
 if (params.identify) { println "\u001B[33mSkipping phage annotation\u001B[0m" }
 println " "
-println "\033[2mCPUs to use: $params.cores\033[0m"
+println "\033[2mCPUs to use: $params.cores, maximal CPUs to use: $params.max_cores\033[0m"
 println " "
 
 /************* 
@@ -740,7 +740,7 @@ def helpMSG() {
     log.info """
     .
     ${c_yellow}Usage examples:${c_reset}
-    nextflow run replikation/What_the_Phage --fasta '*/*.fasta' --cores 20 \\
+    nextflow run replikation/What_the_Phage --fasta '*/*.fasta' --cores 20 --max_cores 40 \\
         --output results -profile local,docker 
 
     nextflow run phage.nf --fasta '*/*.fasta' --cores 20 \\
@@ -773,7 +773,8 @@ def helpMSG() {
 
     ${c_yellow}Options:${c_reset}
     --filter            min contig size [bp] to analyse [default: $params.filter]
-    --cores             max cores for local use [default: $params.cores]
+    --cores             max cores per process for local use [default: $params.cores]
+    --max_cores         max cores used on the machine for local use [default: $params.max_cores]    
     --output            name of the result folder [default: $params.output]
 
     ${c_yellow}Tool control:${c_reset}


### PR DESCRIPTION
Per default, nextflow uses in local mode all cores that are available on the machine. 

However, this can be problematic if the workflow is executed on a large machine w/o any job scheduler or node distribution. 

For example, I just used the workflow on a machine with 120 cores but only wanted to use 60 cores in total for all running processes. 

The current --cores parameter only controls for the maximum number of cores used per process. 

I added a --max_cores parameter that controls in local execution mode the maximum number of cores used on the machine. Per default, this parameter is set to all available cores (see nextflow.config). 

I tested it on a Linux machine. 