### PR TITLE
Decouple virsorter2 database files from image/container

### DIFF
--- a/configs/container.config
+++ b/configs/container.config
@@ -21,7 +21,7 @@ process {
     withLabel: virnet           { container = 'multifractal/virnet-hack:0.1' }
     withLabel: virsorter        { container = 'multifractal/virsorter:0.1.2' }
     withLabel: phigaro          { container = 'multifractal/phigaro:0.5.2' }
-    withLabel: virsorter2       { container = 'multifractal/virsorter-2:0.1' }
+    withLabel: virsorter2       { container = 'papanikos/virsorter-2:latest' }
     withLabel: seeker           { container = 'multifractal/seeker:0.1' }
 
 }

--- a/configs/container.config
+++ b/configs/container.config
@@ -21,7 +21,7 @@ process {
     withLabel: virnet           { container = 'multifractal/virnet-hack:0.1' }
     withLabel: virsorter        { container = 'multifractal/virsorter:0.1.2' }
     withLabel: phigaro          { container = 'multifractal/phigaro:0.5.2' }
-    withLabel: virsorter2       { container = 'papanikos/virsorter-2:latest' }
+    withLabel: virsorter2       { container = 'papanikos/virsorter-2:2.2.1--fa935f8' }
     withLabel: seeker           { container = 'multifractal/seeker:0.1' }
 
 }

--- a/modules/databases/virsorter2_download_DB.nf
+++ b/modules/databases/virsorter2_download_DB.nf
@@ -1,4 +1,4 @@
-process download_virsorter2_DB {
+process virsorter2_download_DB {
     label 'noDocker'    
     if (params.cloudProcess) { publishDir "${params.databases}/virsorter2-db", mode: 'copy' }
     else { storeDir "${params.databases}/virsorter2-db" }  
@@ -7,8 +7,7 @@ process download_virsorter2_DB {
     script:
         """
         wget https://osf.io/v46sc/download -O db.tgz
-        mkdir db
-        tar -zxvf db.tgz --strip-components=1 -C db
+        tar -zxvf db.tgz
         chmod -R a+rX db
         rm db.tgz
         """

--- a/modules/databases/virsorter2_download_DB.nf
+++ b/modules/databases/virsorter2_download_DB.nf
@@ -1,0 +1,15 @@
+process download_virsorter2_DB {
+    label 'noDocker'    
+    if (params.cloudProcess) { publishDir "${params.databases}/virsorter2-db", mode: 'copy' }
+    else { storeDir "${params.databases}/virsorter2-db" }  
+    output:
+        path("virsorter2-db", type: 'dir')
+    script:
+        """
+        wget https://osf.io/v46sc/download -O db.tgz
+        mkdir virsorter2-db
+        tar -zxvf db.tgz virsorter2-db --strip-components=1 -C virsorter2-db
+        chmod a+rX virsorter2-db
+        rm -f db.tgz
+        """
+}

--- a/modules/databases/virsorter2_download_DB.nf
+++ b/modules/databases/virsorter2_download_DB.nf
@@ -3,13 +3,14 @@ process download_virsorter2_DB {
     if (params.cloudProcess) { publishDir "${params.databases}/virsorter2-db", mode: 'copy' }
     else { storeDir "${params.databases}/virsorter2-db" }  
     output:
-        path("virsorter2-db", type: 'dir')
+        path('db', type: 'dir')
     script:
         """
         wget https://osf.io/v46sc/download -O db.tgz
-        mkdir virsorter2-db
-        tar -zxvf db.tgz virsorter2-db --strip-components=1 -C virsorter2-db
-        chmod a+rX virsorter2-db
-        rm -f db.tgz
+        mkdir db
+        tar -zxvf db.tgz --strip-components=1 -C db
+        chmod -R a+rX db
+        rm db.tgz
         """
 }
+

--- a/modules/tools/virsorter2.nf
+++ b/modules/tools/virsorter2.nf
@@ -3,12 +3,16 @@ process virsorter2 {
     errorStrategy 'ignore'
     input:
       tuple val(name), path(fasta)  
+      path(database)
     output:
         tuple val(name), path("virsorter2_*.out/final-viral-score.tsv")
         tuple val(name), path("virsorter2_*.out")
     script:
         """
-        virsorter run -w virsorter2_\${PWD##*/}.out -i ${fasta}  -j ${task.cpus}
+        virsorter run -d ${database} \
+        -w virsorter2_\${PWD##*/}.out \
+        -i ${fasta} \
+        -j ${task.cpus}
         """
 }
 

--- a/phage-tool-Dockerfiles/virsorter2/Dockerfile
+++ b/phage-tool-Dockerfiles/virsorter2/Dockerfile
@@ -1,0 +1,13 @@
+FROM continuumio/miniconda3
+
+RUN apt-get update && apt-get install -y procps && \
+    apt-get upgrade -y && apt-get autoremove
+
+RUN conda config --add channels conda-forge && \
+    conda config --add channels bioconda && \
+    conda config --add channels default
+
+RUN conda install -y -c bioconda virsorter=2
+
+RUN conda clean -y --all
+


### PR DESCRIPTION
Hi @replikation @mult1fractal @hoelzer ,

This mainly addresses #121 .

I followed the same conventions as with the other tools that require an input db and created a separate module for fetching virsorter2 data. 
* A `virsorter2-db` directory is created in the provided `--databases` location.
* When unpacking the `tar.gz` permissions are set, so this solves my original issue.

A new dockerfile is also included under `phage-tool-Dockerfiles` , so feel free to do whatever you want with it.
* For testing I used my own image available [here](https://hub.docker.com/r/papanikos/virsorter-2/tags?page=1&ordering=last_updated) . I included this in the `container.config` and is included in this PR.

I only tested it with the local singularity profile like this
```
nextflow ./phage.nf \
-profile smalltest,local,singularity \
--workdir ./workdir \
--identify \
--dv --ma --sk --mp --pp --vs --sm --vb --vn --ph
```

and worked fine.

PS: Sorry for some commits changing the same file again and again, I had my issues...