### PR TITLE
rm container option that crashes singularity

### DIFF
--- a/configs/container.config
+++ b/configs/container.config
@@ -12,7 +12,7 @@ process {
     withLabel: prodigal         { container = 'nanozoo/prodigal:2.6.3--2769024' }
     withLabel: python           { container = 'nanozoo/template:3.8--ccd0653' }
     withLabel: samtools         { container = 'nanozoo/samtools:1.9--76b9270' }
-    withLabel: seqkit           { container = 'nanozoo/seqkit:0.13.2--cd66104' ; containerOptions = '--shm-size 2g' }
+    withLabel: seqkit           { container = 'nanozoo/seqkit:0.13.2--cd66104'}
     withLabel: sourmash         { container = 'nanozoo/sourmash:4.5.0--e12a57a' }
     withLabel: ubuntu           { container = 'nanozoo/basics:1.0--962b907' }
     withLabel: upsetr           { container = 'nanozoo/upsetr:1.4.0--0ea25b3' }

--- a/nextflow.config
+++ b/nextflow.config
@@ -161,7 +161,8 @@ profiles {
                 enabled = true
                 autoMounts = true
                 cacheDir = params.cachedir
-                envWhitelist = 'SINGULARITY_LOCALCACHEDIR'
+                //envWhitelist = 'SINGULARITY_LOCALCACHEDIR'
+                envWhiteList = "HTTPS_PROXY,HTTP_PROXY,http_proxy,https_proxy,FTP_PROXY,ftp_proxy"
         }
         includeConfig 'configs/container.config'
     }

--- a/workflows/process/sourmash/sourmash.nf
+++ b/workflows/process/sourmash/sourmash.nf
@@ -23,6 +23,7 @@ process sourmash {
           filename=\$(basename \${tempfile} .fa.sig.temporary)
           prediction_value=\$(grep -v "similarity,md5,filename,name,query_filename,query_name,query_md5,ani" \${tempfile} |sort -r -k1 | awk 'NR == 1' | cut -d "," -f1 )
       
+	  touch ${name}_\${PWD##*/}.list
           if [ \$value -gt 0 ] 
             then echo "\$filename,\$prediction_value" >> ${name}_\${PWD##*/}.list
           fi

--- a/workflows/process/virsorter/filter_virsorter.nf
+++ b/workflows/process/virsorter/filter_virsorter.nf
@@ -26,10 +26,14 @@ process filter_virsorter {
                 echo "\$line,0" >> pro_phage_virsorter.tsv
             fi
         done < virsorter_categorized_contigs_*.list
-        grep ">" virsorter_phage.tsv | \\
-        sed -e s/\\>VIRSorter_//g | \\
-        sed -e s/\\-cat_[1-3]//g | \\
-        awk -F, '{print \$1, \$2}' OFS="\\t"  > virsorter_\${PWD##*/}.tsv
-        rm virsorter_phage.tsv
+	if [ -s virsorter_phage.tsv ]; then
+           grep ">" virsorter_phage.tsv | \\
+           sed -e s/\\>VIRSorter_//g | \\
+           sed -e s/\\-cat_[1-3]//g | \\
+           awk -F, '{print \$1, \$2}' OFS="\\t"  > virsorter_\${PWD##*/}.tsv
+           rm virsorter_phage.tsv
+	else
+	 touch virsorter_\${PWD##*/}.tsv
+	fi
         """
 }

--- a/workflows/process/virsorter_virome/filter_virsorter_virome.nf
+++ b/workflows/process/virsorter_virome/filter_virsorter_virome.nf
@@ -27,10 +27,14 @@ process filter_virsorter_virome {
             fi
         done < virsorter_categorized_contigs_*.list
 
-        grep ">" virsorter_phage.tsv | \\
-        sed -e s/\\>VIRSorter_//g | \\
-        sed -e s/\\-cat_[1-3]//g | \\
-        awk -F, '{print \$1, \$2}' OFS="\\t" > virsorter-virome_\${PWD##*/}.tsv
-        rm virsorter_phage.tsv
+	if [ -s virsorter_phage.tsv ]; then
+           grep ">" virsorter_phage.tsv | \\
+           sed -e s/\\>VIRSorter_//g | \\
+           sed -e s/\\-cat_[1-3]//g | \\
+           awk -F, '{print \$1, \$2}' OFS="\\t" > virsorter-virome_\${PWD##*/}.tsv
+           rm virsorter_phage.tsv
+	else
+	   touch virsorter-virome_\${PWD##*/}.tsv
+	fi
         """
 }


### PR DESCRIPTION
Removed the container option from

```bash
    withLabel: seqkit           { container = 'nanozoo/seqkit:0.13.2--cd66104' ; containerOptions = '--shm-size 2g' }
```

bc this is a Docker option and if coded like that it crashes Singularity. Also, it is probably not needed anyway. 

I am doing some further tests on SLURM/Singularity and will then report here if the PR is ready