### PR TITLE
Quickfix

### DIFF
--- a/.github/workflows/nextflow-test.yml
+++ b/.github/workflows/nextflow-test.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Help_test
-      run: curl -s https://get.nextflow.io | bash && NXF_VER=24.11.0 ./nextflow info && ./nextflow run phage.nf --help
+      run: curl -s https://get.nextflow.io | bash && NXF_VER=24.11.0-edge ./nextflow info && ./nextflow run phage.nf --help
     - name: fasta dry run whole wf
       run: |
           ./nextflow run phage.nf --fasta ./test-data/stub_genome.fasta -stub -profile stub --cores 2 --max_cores 2

--- a/.github/workflows/nextflow-test.yml
+++ b/.github/workflows/nextflow-test.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Help_test
-      run: curl -s https://get.nextflow.io | bash && NXF_VER=24.11.0-edge ./nextflow info | bash && ./nextflow run phage.nf --help
+      run: curl -s https://get.nextflow.io | bash && NXF_VER=24.11.0-edge && ./nextflow run phage.nf --help
     - name: fasta dry run whole wf
       run: |
           ./nextflow run phage.nf --fasta ./test-data/stub_genome.fasta -stub -profile stub --cores 2 --max_cores 2

--- a/.github/workflows/nextflow-test.yml
+++ b/.github/workflows/nextflow-test.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Help_test
-      run: curl -s https://get.nextflow.io | bash && NXF_VER=24.11.0 nextflow info && ./nextflow run phage.nf --help
+      run: curl -s https://get.nextflow.io | bash && NXF_VER=24.11.0 ./nextflow info && ./nextflow run phage.nf --help
     - name: fasta dry run whole wf
       run: |
           ./nextflow run phage.nf --fasta ./test-data/stub_genome.fasta -stub -profile stub --cores 2 --max_cores 2

--- a/.github/workflows/nextflow-test.yml
+++ b/.github/workflows/nextflow-test.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Help_test
-      run: curl -s https://get.nextflow.io | bash && ./nextflow self-update && NXF_VER=24.11.0-edge && ./nextflow run phage.nf --help
+      run: curl -s https://get.nextflow.io | bash && NXF_EDGE=1 ./nextflow self-update && ./nextflow run phage.nf --help
     - name: fasta dry run whole wf
       run: |
           ./nextflow run phage.nf --fasta ./test-data/stub_genome.fasta -stub -profile stub --cores 2 --max_cores 2

--- a/.github/workflows/nextflow-test.yml
+++ b/.github/workflows/nextflow-test.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Help_test
-      run: curl -s https://get.nextflow.io | bash && NXF_VER=24.11.0-edge && ./nextflow run phage.nf --help
+      run: curl -s https://get.nextflow.io | bash && ./nextflow self-update && NXF_VER=24.11.0-edge && ./nextflow run phage.nf --help
     - name: fasta dry run whole wf
       run: |
           ./nextflow run phage.nf --fasta ./test-data/stub_genome.fasta -stub -profile stub --cores 2 --max_cores 2

--- a/.github/workflows/nextflow-test.yml
+++ b/.github/workflows/nextflow-test.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Help_test
-      run: curl -s https://get.nextflow.io | bash && NXF_VER=24.11.0-edge ./nextflow info && ./nextflow run phage.nf --help
+      run: curl -s https://get.nextflow.io | bash && NXF_VER=24.11.0-edge ./nextflow info | bash && ./nextflow run phage.nf --help
     - name: fasta dry run whole wf
       run: |
           ./nextflow run phage.nf --fasta ./test-data/stub_genome.fasta -stub -profile stub --cores 2 --max_cores 2

--- a/.github/workflows/nextflow-test.yml
+++ b/.github/workflows/nextflow-test.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Help_test
-      run: curl -s https://get.nextflow.io | bash && ./nextflow run phage.nf --help
+      run: curl -s https://get.nextflow.io | bash && NXF_VER=24.11.0 nextflow info && ./nextflow run phage.nf --help
     - name: fasta dry run whole wf
       run: |
           ./nextflow run phage.nf --fasta ./test-data/stub_genome.fasta -stub -profile stub --cores 2 --max_cores 2

--- a/workflows/process/seeker/seeker.nf
+++ b/workflows/process/seeker/seeker.nf
@@ -14,5 +14,6 @@ process seeker {
         """
         echo "name	prediction	score" > ${name}_\${PWD##*/}.list
         echo "pos_phage_0	Phage	0.82" >> ${name}_\${PWD##*/}.list
+        
         """
 }


### PR DESCRIPTION
nextflow version 24.10.4 has a bug  in -stub
by setting a specific release candidate you can prevent the -stub failing :
run: curl -s https://get.nextflow.io/ | bash && NXF_EDGE=1 ./nextflow self-update && ./nextflow run phage.nf --help